### PR TITLE
Query for get similar places geojson response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,16 @@
 			<artifactId>json-path-assert</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-commons</artifactId>
+			<version>RELEASE</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.9</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/climatetree/places/controller/PlacesController.java
+++ b/src/main/java/com/climatetree/places/controller/PlacesController.java
@@ -32,7 +32,6 @@ public class PlacesController {
 	public String getSimilarPlaces(@PathVariable("placeId") int placeId,
 																 @RequestParam(required = false) Integer start,
 																 @RequestParam(required = false) Integer end) {
-		System.out.println(String.valueOf(start) + String.valueOf(end));
 		return placesService.getSimilarPlaces(placeId, start, end);
 	}
 

--- a/src/main/java/com/climatetree/places/controller/PlacesController.java
+++ b/src/main/java/com/climatetree/places/controller/PlacesController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.climatetree.places.dto.PlaceDTO;
@@ -28,10 +29,13 @@ public class PlacesController {
 	NamesService namesService;
 
 	@GetMapping("/places/{placeId}/similar")
-	public List<PlaceDTO> getSimilarPlaces(@PathVariable("placeId") int placeId) {
-		return placesService.getSimilarPlaces(placeId);
+	public String getSimilarPlaces(@PathVariable("placeId") int placeId,
+																 @RequestParam(required = false) Integer start,
+																 @RequestParam(required = false) Integer end) {
+		System.out.println(String.valueOf(start) + String.valueOf(end));
+		return placesService.getSimilarPlaces(placeId, start, end);
 	}
-	
+
 	@GetMapping("/places/{name}")
 	public String getPlacesByName(@PathVariable("name") String name) {
 		return namesService.getPlacesBySearchTerm(name);

--- a/src/main/java/com/climatetree/places/controller/PlacesController.java
+++ b/src/main/java/com/climatetree/places/controller/PlacesController.java
@@ -30,9 +30,9 @@ public class PlacesController {
 
 	@GetMapping("/places/{placeId}/similar")
 	public String getSimilarPlaces(@PathVariable("placeId") int placeId,
-																 @RequestParam(required = false) Integer start,
-																 @RequestParam(required = false) Integer end) {
-		return placesService.getSimilarPlaces(placeId, start, end);
+																 @RequestParam(required = false) Integer populationStart,
+																 @RequestParam(required = false) Integer populationEnd) {
+		return placesService.getSimilarPlaces(placeId, populationStart, populationEnd);
 	}
 
 	@GetMapping("/places/{name}")

--- a/src/main/java/com/climatetree/places/dao/NameRepository.java
+++ b/src/main/java/com/climatetree/places/dao/NameRepository.java
@@ -15,10 +15,21 @@ public interface NameRepository extends CrudRepository<Name, Integer> {
 			+ "  		  ST_AsGeoJSON(place.point)\\:\\:json As geometry,\n"
 			+ "  		  row_to_json((SELECT l FROM (SELECT place.place_id, population, carbon, percapcarb, popdensity, biomass, coal,\n"
 			+ "						cogeneration, gas, geothermal, hydro, nuclear, oil, other, petcoke, solar, storage,\n"
-			+ "						 waste, wave_and_tidal, wind, n.name) As l\n" + "  		    )) As properties\n"
+			+ "						 waste, wave_and_tidal, wind, n.name, n_0.name as \"nation_name\", n_1.name  as \"state_name\", n_2.name  as \"county_name\") As l\n" + "  		    )) As properties\n"
 			+ "  		 FROM public.\"PLACE_INFO\" as place \n" + "			JOIN public.\"NAME_PLACE\" as np\n"
 			+ "	     		ON place.place_id = np.place_id\n" + "	   		JOIN public.\"NAME\" as n\n"
-			+ "	   		ON np.name_id = n.name_id\n" + "  		 WHERE upper(n.name) LIKE ?1%\n" + "         ) As f \n"
+			+ "	   		ON np.name_id = n.name_id\n"
+
+			+		"LEFT JOIN public.\"NAME_PLACE\" as np_0\n"
+			+		"on place.gadm_0_id = np_0.place_id JOIN public.\"NAME\" as n_0 on np_0.name_id = n_0.name_id\n"
+
+			+		"LEFT JOIN public.\"NAME_PLACE\" as np_1\n"
+			+		"on place.gadm_1_id = np_1.place_id left JOIN public.\"NAME\" as n_1 on np_1.name_id = n_1.name_id\n"
+
+			+		"LEFT JOIN public.\"NAME_PLACE\" as np_2\n"
+			+		"on place.gadm_2_id = np_2.place_id left JOIN public.\"NAME\" as n_2 on np_2.name_id = n_2.name_id\n"
+
+			+		"  		 WHERE upper(n.name) LIKE ?1%\n" + "         ) As f \n"
 			+ "	   ) As fc;", nativeQuery = true)
 	public String getPlacesBySearchTerm(String upperName);
 

--- a/src/main/java/com/climatetree/places/dao/PlaceRepository.java
+++ b/src/main/java/com/climatetree/places/dao/PlaceRepository.java
@@ -16,18 +16,35 @@ public interface PlaceRepository extends CrudRepository<PlaceInfo, Integer> {
 	 * Queries the database for PlaceInfo entries that are within the following range:
 	 *  - Population is greater than popStart
 	 *  - Population is less than popEnd
-	 *  - Population density is greater than popDensityStart
-	 *  - Population density is less than popDensityEnd
 	 * 
 	 * @param popStart start of the population range
 	 * @param popEnd end of the population range
-	 * @param popDensityStart start of the population density range
-	 * @param popDensityEnd end of the population density range
+   * @param typeId the type id ( 1 = state, 2 = nation , 3 = county, 4 = urbanextent)
 	 * @return a list of PlaceInfo objects
 	 */
-	@Query("Select place from PlaceInfo place WHERE place.population>=:popStart AND place.population<=:popEnd AND place.popdensity>=:popDensityStart AND place.popdensity<=:popDensityEnd")
-	public List<PlaceInfo> getSimilarPlaces(@Param("popStart") double popStart, 
-											@Param("popEnd") double popEnd, 
-											@Param("popDensityStart") double popDensityStart,
-											@Param("popDensityEnd") double popDensityEnd);
+	@Query(value = "SELECT cast(row_to_json(fc) as character varying)\n"
+					+ " FROM ( SELECT 'FeatureCollection' As type, array_to_json(array_agg(f)) As features\n"
+					+ "	 	FROM (SELECT 'Feature' As type,\n"
+					+ "  		  ST_AsGeoJSON(place.point)\\:\\:json As geometry,\n"
+					+ "  		  row_to_json((SELECT l FROM (SELECT place.place_id, type.type_name, population, carbon, percapcarb, popdensity, biomass, coal,\n"
+					+ "						cogeneration, gas, geothermal, hydro, nuclear, oil, other, petcoke, solar, storage,\n"
+					+ "						 waste, wave_and_tidal, wind, n.name, n_0.name as \"nation_name\", n_1.name  as \"state_name\", n_2.name  as \"county_name\") As l\n" + "  		    )) As properties\n"
+					+ "  		 FROM public.\"PLACE_INFO\" as place \n" + "			JOIN public.\"NAME_PLACE\" as np\n"
+					+ "	     		ON place.place_id = np.place_id\n" + "	   		JOIN public.\"NAME\" as n\n"
+					+ "	   		ON np.name_id = n.name_id\n"
+
+					+		"LEFT JOIN public.\"NAME_PLACE\" as np_0\n"
+					+		"on place.gadm_0_id = np_0.place_id JOIN public.\"NAME\" as n_0 on np_0.name_id = n_0.name_id\n"
+
+					+		"LEFT JOIN public.\"NAME_PLACE\" as np_1\n"
+					+		"on place.gadm_1_id = np_1.place_id left JOIN public.\"NAME\" as n_1 on np_1.name_id = n_1.name_id\n"
+
+					+		"LEFT JOIN public.\"NAME_PLACE\" as np_2\n"
+					+		"on place.gadm_2_id = np_2.place_id left JOIN public.\"NAME\" as n_2 on np_2.name_id = n_2.name_id\n"
+					+ 	"LEFT JOIN public.\"TYPE\" as type\n"
+					+		"on place.type_id = type.type_id\n"
+					+		"WHERE place.population>=:popStart AND place.population<=:popEnd AND place.type_id=:typeId) As f \n"
+					+ "	   ) As fc;", nativeQuery = true)
+	public String getSimilarPlaces(@Param("popStart") double popStart,
+											@Param("popEnd") double popEnd,@Param("typeId") int typeId);
 }

--- a/src/main/java/com/climatetree/places/service/PlacesService.java
+++ b/src/main/java/com/climatetree/places/service/PlacesService.java
@@ -18,6 +18,10 @@ public class PlacesService {
 	@Autowired
 	PlaceRepository placesRepo;
 
+	private final int defaultStart = 95;
+	private final int defaultEnd = 150;
+
+
 	public PlaceInfo findPlaceById(int placeId) {
 		Optional<PlaceInfo> placesOp = placesRepo.findById(placeId);
 		return placesOp.isPresent() ? placesOp.get() : null;
@@ -31,26 +35,31 @@ public class PlacesService {
 
 	/**
 	 * Returns places that adhere to all of the following constraints when compared
-	 * to the given place: 1. Between 95% to 150% of the given place's population 2.
-	 * Between 95% to 150% of the given place's population density
+	 * to the given place: 1. Between percentStart and percentEnd of the given place's population 2.
+	 * Is the same type (nation, state, county, or urban extent) as the given place.
 	 * 
-	 * @param place a PlaceDTO object
+	 * @param placeId the placeId of a Place
+	 * @param percentStart the starting value for the population range percentage (95% should given as
+	 *                      95)
+	 * @param percentEnd the ending value for the population range percentage (150% should be given as
+	 *                   150)
 	 * @return a list of PlaceDTO objects that are "similar" to the given PlaceDTO
 	 */
-	public List<PlaceDTO> getSimilarPlaces(int placeId) {
-		List<PlaceDTO> places = new ArrayList<>();
+	public String getSimilarPlaces(int placeId, Integer percentStart, Integer percentEnd) {
 		Optional<PlaceInfo> placeOpt = placesRepo.findById(placeId);
+
+		int start = (percentStart != null) ? percentStart : defaultStart;
+		int end = (percentEnd != null) ? percentEnd : defaultEnd;
+
 		if (placeOpt.isPresent()) {
 			PlaceInfo place = placeOpt.get();
-			double pop_start = place.getPopulation() * .95;
-			double pop_end = place.getPopulation() * 1.50;
-			double popDensity_start = place.getPopdensity() * .95;
-			double popDensity_end = place.getPopdensity() * 1.50;
+			double popStart = place.getPopulation() * ((double) start / 100);
+			double popEnd = place.getPopulation() * ((double) end / 100);
+			int typeId = place.getType().getTypeId();
 
-			this.placesRepo.getSimilarPlaces(pop_start, pop_end, popDensity_start, popDensity_end)
-					.forEach(p -> places.add(Mapper.placeInfoToPlaceDTO(p)));
+			return this.placesRepo.getSimilarPlaces(popStart, popEnd, typeId);
 		}
-		return places;
+		return "";
 	}
 
 }

--- a/src/main/java/com/climatetree/places/service/PlacesService.java
+++ b/src/main/java/com/climatetree/places/service/PlacesService.java
@@ -1,25 +1,31 @@
 package com.climatetree.places.service;
 
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Service;
 
-import com.climatetree.places.dto.PlaceDTO;
 import com.climatetree.places.dao.PlaceRepository;
 import com.climatetree.places.model.PlaceInfo;
-import com.climatetree.places.utils.Mapper;
 
 @Service
+@PropertySource("classpath:constants.properties")
 public class PlacesService {
 
 	@Autowired
 	PlaceRepository placesRepo;
 
-	private final int defaultStart = 95;
-	private final int defaultEnd = 150;
+	@Value("${default_population_start}")
+	private int defaultStart;
+
+  @Value("${default_population_end}")
+	private int defaultEnd;
 
 
 	public PlaceInfo findPlaceById(int placeId) {
@@ -59,7 +65,7 @@ public class PlacesService {
 
 			return this.placesRepo.getSimilarPlaces(popStart, popEnd, typeId);
 		}
-		return "";
+		return StringUtils.EMPTY;
 	}
 
 }

--- a/src/main/resources/constants.properties
+++ b/src/main/resources/constants.properties
@@ -1,0 +1,3 @@
+# Constant Values
+default_population_start=95
+default_population_end=150

--- a/src/test/java/com/climatetree/places/controller/PlacesControllerTest.java
+++ b/src/test/java/com/climatetree/places/controller/PlacesControllerTest.java
@@ -61,7 +61,7 @@ public class PlacesControllerTest {
 
 		when(placeService.getSimilarPlaces(anyInt(), anyInt(), anyInt())).thenReturn(geoJsonString);
 
-		mvc.perform(get("/api/places/1/similar?start=90&end=100").contentType(APPLICATION_JSON)).andExpect(status().isOk())
+		mvc.perform(get("/api/places/1/similar?populationStart=90&populationEnd=100").contentType(APPLICATION_JSON)).andExpect(status().isOk())
 				.andExpect(jsonPath("$", is(geoJsonString)));
 	}
 }

--- a/src/test/java/com/climatetree/places/controller/PlacesControllerTest.java
+++ b/src/test/java/com/climatetree/places/controller/PlacesControllerTest.java
@@ -57,24 +57,11 @@ public class PlacesControllerTest {
 
 	@Test
 	public void getSimilarPlacesTest() throws Exception {
-		List<PlaceDTO> places = new ArrayList<>();
-		PlaceDTO dto1 = new PlaceDTO(1, "Manchester", null, 1, 2, 3, 4, 5, 6);
-		PlaceDTO dto2 = new PlaceDTO(2, "Boston", null, 1.50, 2, 3, 5.00, 5, 6);
+		String geoJsonString = "Test Dummy Geo Json String";
 
-		places.add(dto1);
-		places.add(dto2);
+		when(placeService.getSimilarPlaces(anyInt(), anyInt(), anyInt())).thenReturn(geoJsonString);
 
-		when(placeService.getSimilarPlaces(anyInt())).thenReturn(places);
-
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
-		ObjectWriter ow = mapper.writer().withDefaultPrettyPrinter();
-		String body = ow.writeValueAsString(dto1);
-
-		List<PlaceDTO> placesList = new ArrayList<>(places);
-		mvc.perform(get("/api/places/1/similar").contentType(APPLICATION_JSON).content(body)).andExpect(status().isOk())
-				.andExpect(jsonPath("$", hasSize(2)))
-				.andExpect(jsonPath("$[0].placeId", is(placesList.get(0).getPlaceId())))
-				.andExpect(jsonPath("$[1].placeId", is(placesList.get(1).getPlaceId())));
+		mvc.perform(get("/api/places/1/similar?start=90&end=100").contentType(APPLICATION_JSON)).andExpect(status().isOk())
+				.andExpect(jsonPath("$", is(geoJsonString)));
 	}
 }

--- a/src/test/java/com/climatetree/places/dao/PlacesRepositoryTest.java
+++ b/src/test/java/com/climatetree/places/dao/PlacesRepositoryTest.java
@@ -3,55 +3,32 @@ package com.climatetree.places.dao;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.jdbc.Sql;
-
 import com.climatetree.places.model.PlaceInfo;
 
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-import java.util.List;
-
-import javax.persistence.EntityManager;
-import javax.sql.DataSource;
+import java.util.HashSet;
+import java.util.Set;
 
 @DataJpaTest
 public class PlacesRepositoryTest {
-	
-	@Autowired private DataSource dataSource;
-	@Autowired private JdbcTemplate jdbcTemplate;
-	@Autowired private EntityManager entityManager;
-	@Autowired private PlaceRepository placesRepository;
-	
-	@Test
-	void injectedComponentsAreNotNullTest(){
-	  assertThat(dataSource).isNotNull();
-	  assertThat(jdbcTemplate).isNotNull();
-	  assertThat(entityManager).isNotNull();
-	  assertThat(placesRepository).isNotNull();
-	}
-	  	  
-	@Test
-	@Sql(scripts={"classpath:createPlace.sql"})
-	void placesRepositoryTest() {
-		List<PlaceInfo> actual = placesRepository.getSimilarPlaces(.95, 1.25, 3.8, 5.0);
 
-		boolean[] success = {false, false, false, false, false};
-		
-		for (int i = 0; i < actual.size(); i++) {
-			int id = actual.get(i).getPlaceId();
-			success[id] = true;
-		}
-		
-		boolean total_success = true;
-		for(boolean b : success) if(!b) total_success = false;
-		
-		assertThat(actual).isNotNull();
-		assertThat(total_success).isTrue();
-		assertThat(actual).hasSize(5);
-		
+	@Autowired private PlaceRepository repository;
+
+	@Test
+	void saveAndFindByIdTest() {
+		Set<PlaceInfo> places1 = new HashSet<>();
+		PlaceInfo p1 = new PlaceInfo(1, null, null, null, null, null, 10.0, 11.0, 12.0, 13.0, "h1", 22.0, 22.5);
+		PlaceInfo p2 = new PlaceInfo(2, null, null, null, null, null, 14.0, 16.0, 11.0, 33.0, "h2", 26.0, 27.5);
+		places1.add(p1);
+		places1.add(p2);
+
+		repository.save(p1);
+		PlaceInfo place = repository.findById(p1.getPlaceId()).isPresent() ? repository.findById(p1.getPlaceId()).get() : null;
+
+		assertNotNull(place);
+		assertEquals(place.getPopulation(), p1.getPopulation(), .001);
 	}
-	  
- 
 }

--- a/src/test/java/com/climatetree/places/service/PlacesServiceTest.java
+++ b/src/test/java/com/climatetree/places/service/PlacesServiceTest.java
@@ -5,9 +5,7 @@ import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.Before;
@@ -19,7 +17,6 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.climatetree.places.dao.PlaceRepository;
-import com.climatetree.places.dto.PlaceDTO;
 import com.climatetree.places.model.EcoName;
 import com.climatetree.places.model.PlaceInfo;
 import com.climatetree.places.model.Type;
@@ -30,40 +27,51 @@ import com.climatetree.places.model.WwfRealm2;
 public class PlacesServiceTest {
 	
 	@InjectMocks
-	PlacesService service;
-	
+	private PlacesService service;
+
+	private String json_object;
+	private PlaceInfo repoParam;
+
 	@Mock
 	private PlaceRepository repo;
 
 	@Before
 	public void setUp() throws Exception {
 		MockitoAnnotations.initMocks(this);
-	}
-
-	@Test
-	public void getSimilarPlacesTest() {
 		// Create a PlaceInfo object
 		Type type = new Type(1, "type", new HashSet<PlaceInfo>());
 		EcoName ecoName = new EcoName(2, "ecoName", new HashSet<PlaceInfo>());
 		WwfMhtnam wwfmhtnam = new WwfMhtnam(3, "wwfmhtnam", new HashSet<PlaceInfo>());
 		WwfRealm2 wwfrealm2 = new WwfRealm2(4, "wwfrealm2", new HashSet<PlaceInfo>());
-		PlaceInfo repoParam = new PlaceInfo(0, type, ecoName, wwfmhtnam, wwfrealm2, 1.0, 2.0, 3.0, 4.0, "hasc1", 5.0, 6.0);
+		repoParam = new PlaceInfo(0, type, ecoName, wwfmhtnam, wwfrealm2, 1.0, 2.0, 3.0, 4.0, "hasc1", 5.0, 6.0);
 
 		// Add the object to an ArrayList
-		String json_object = "Json Object";
+		json_object = "Json Object";
 
-		// When we call findById on our repo, return the above repoParam we created
+		// When we call findById on our repo
 		when(repo.findById(anyInt())).thenReturn(Optional.of(repoParam));
+		}
 
-		// When we call getSimilarPlaces on our repo, return the above list we created
+	@Test
+	public void getSimilarPlacesTest1() {
+		// When we call getSimilarPlaces on our repo
 		when(repo.getSimilarPlaces(anyDouble(), anyDouble(), anyInt())).thenReturn(json_object);
 
-		// call the placesService.ggitetSimilarPlaces function
-		PlaceDTO param = new PlaceDTO(0, "", "", 1.0, 2.0, 3.0, 4.0, 5, 6);
-		String places = service.getSimilarPlaces(param.getPlaceId(), 95, 150);
+		String places = service.getSimilarPlaces(0, 95, 150);
 
 		// Assert that our function returned the right information
 		assertThat(places).isEqualTo("Json Object");
+	}
+
+	@Test
+	public void getSimilarPlacesTest2() {
+		// When we call getSimilarPlaces on our repo
+		when(repo.findById(anyInt())).thenReturn(Optional.empty());
+
+		String places = service.getSimilarPlaces(0, 95, 150);
+
+		// Assert that our function returned the right information
+		assertThat(places).isEqualTo("");
 	}
 
 }

--- a/src/test/java/com/climatetree/places/service/PlacesServiceTest.java
+++ b/src/test/java/com/climatetree/places/service/PlacesServiceTest.java
@@ -25,7 +25,6 @@ import com.climatetree.places.model.PlaceInfo;
 import com.climatetree.places.model.Type;
 import com.climatetree.places.model.WwfMhtnam;
 import com.climatetree.places.model.WwfRealm2;
-import com.climatetree.places.utils.Mapper;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PlacesServiceTest {
@@ -49,24 +48,22 @@ public class PlacesServiceTest {
 		WwfMhtnam wwfmhtnam = new WwfMhtnam(3, "wwfmhtnam", new HashSet<PlaceInfo>());
 		WwfRealm2 wwfrealm2 = new WwfRealm2(4, "wwfrealm2", new HashSet<PlaceInfo>());
 		PlaceInfo repoParam = new PlaceInfo(0, type, ecoName, wwfmhtnam, wwfrealm2, 1.0, 2.0, 3.0, 4.0, "hasc1", 5.0, 6.0);
-		
+
 		// Add the object to an ArrayList
-		List<PlaceInfo> our_list = new ArrayList<>();
-		our_list.add(repoParam);
-		
+		String json_object = "Json Object";
+
 		// When we call findById on our repo, return the above repoParam we created
 		when(repo.findById(anyInt())).thenReturn(Optional.of(repoParam));
-		
+
 		// When we call getSimilarPlaces on our repo, return the above list we created
-		when(repo.getSimilarPlaces(anyDouble(), anyDouble(), anyDouble(), anyDouble())).thenReturn(our_list);
-		
+		when(repo.getSimilarPlaces(anyDouble(), anyDouble(), anyInt())).thenReturn(json_object);
+
 		// call the placesService.ggitetSimilarPlaces function
 		PlaceDTO param = new PlaceDTO(0, "", "", 1.0, 2.0, 3.0, 4.0, 5, 6);
-		List<PlaceDTO> places = service.getSimilarPlaces(param.getPlaceId());
-		
+		String places = service.getSimilarPlaces(param.getPlaceId(), 95, 150);
+
 		// Assert that our function returned the right information
-		assertThat(places).hasSize(1);
-		assertThat(places.get(0)).isEqualTo(Mapper.placeInfoToPlaceDTO(repoParam));
+		assertThat(places).isEqualTo("Json Object");
 	}
 
 }


### PR DESCRIPTION
### Change type:
- New feature

### Description:
- Adds a query that for getSimilarPlaces API that returns a geojson object
- Parameterized the getSimilarPlaces API to allow a percent range for population (i.e. 95% - 150% is defualt if omitted)
- Also returns the nation, state, and county names in the geojson objects for both getSimilarPlaces and getPlacesBySearchTerm

### Trello Card Link:
https://trello.com/c/tIkwTIT0/51-update-similar-places-api-to-accept-arguments-for-population-percentage-range-and-join-on-nation-state-and-county-info

https://trello.com/c/xblMuJsu/52-update-find-place-by-name-api-to-join-place-info-on-nation-state-and-county

### PR Checklist:
- [X] Changes do not introduce new warnings or errors
- [X] Tests were added or modified to cover changes
- [X] All new and existing tests pass

### Steps to Verify Pull Request
- Review new queries
- Review the new api endpoint and parameters
- Review new tests
