### PR TITLE
Added nearest endpoint

### DIFF
--- a/src/main/java/com/climatetree/places/controller/PlacesController.java
+++ b/src/main/java/com/climatetree/places/controller/PlacesController.java
@@ -39,5 +39,10 @@ public class PlacesController {
 	public String getPlacesByName(@PathVariable("name") String name) {
 		return namesService.getPlacesBySearchTerm(name);
 	}
+
+	@GetMapping("/places/nearest")
+  public String getNearestPlace(@RequestParam double latitude, @RequestParam double longitude){
+	  return placesService.getNearbyPlace(latitude, longitude);
+  }
 	
 }

--- a/src/main/java/com/climatetree/places/dao/PlaceRepository.java
+++ b/src/main/java/com/climatetree/places/dao/PlaceRepository.java
@@ -47,4 +47,40 @@ public interface PlaceRepository extends CrudRepository<PlaceInfo, Integer> {
 					+ "	   ) As fc;", nativeQuery = true)
 	public String getSimilarPlaces(@Param("popStart") double popStart,
 											@Param("popEnd") double popEnd,@Param("typeId") int typeId);
+
+  /**
+   * Queries the database and finds the nearest place to the given latitude and longitude
+   * by elucidaian distance.
+   * @param latitude the latitude to search near
+   * @param longitude the longitude to search near
+   * @return geoJSON string representing the found place
+   */
+	@Query(value = "SELECT cast(row_to_json(fc) as character varying)\n"
+      + " FROM ( SELECT 'FeatureCollection' As type, array_to_json(array_agg(f)) As features\n"
+      + "FROM (SELECT 'Feature' As type,\n"
+      + "       ST_AsGeoJSON(place.point)\\:\\:json As geometry,\n"
+      + "       row_to_json((SELECT l FROM (SELECT place.place_id, type.type_name, population, carbon, percapcarb, popdensity, biomass, coal,\n"
+      + "       cogeneration, gas, geothermal, hydro, nuclear, oil, other, petcoke, solar, storage,\n"
+      + "       waste, wave_and_tidal, wind, n.name, n_0.name as \"nation_name\", n_1.name  as \"state_name\", n_2.name  as \"county_name\") As l\n"
+      + "        )) As properties\n"
+      + " FROM public.\"PLACE_INFO\" as place \n"
+      + "JOIN public.\"NAME_PLACE\" as np ON place.place_id = np.place_id\n"
+      + "JOIN public.\"NAME\" as n ON np.name_id = n.name_id\n"
+
+      + "LEFT JOIN public.\"NAME_PLACE\" as np_0 ON place.gadm_0_id = np_0.place_id\n"
+      + "LEFT JOIN public.\"NAME\" as n_0 on np_0.name_id = n_0.name_id\n"
+
+      + "LEFT JOIN public.\"NAME_PLACE\" as np_1 ON place.gadm_1_id = np_1.place_id \n"
+      + "LEFT JOIN public.\"NAME\" as n_1 ON np_1.name_id = n_1.name_id\n"
+
+      + "LEFT JOIN public.\"NAME_PLACE\" as np_2 ON place.gadm_2_id = np_2.place_id \n"
+      + "LEFT JOIN public.\"NAME\" as n_2 ON np_2.name_id = n_2.name_id\n"
+
+      + "LEFT JOIN public.\"TYPE\" as type ON place.type_id = type.type_id\n"
+
+      + "ORDER BY point <-> ST_SetSRID( ST_Point(:longitude, :latitude), 4326)\\:\\:geometry \n"
+      + "LIMIT 1\n"
+      + ") As f \n"
+      + ") As fc;", nativeQuery = true)
+	String getNearestPlace(@Param("latitude") double latitude, @Param("longitude") double longitude);
 }

--- a/src/main/java/com/climatetree/places/service/PlacesService.java
+++ b/src/main/java/com/climatetree/places/service/PlacesService.java
@@ -68,4 +68,14 @@ public class PlacesService {
 		return StringUtils.EMPTY;
 	}
 
+  /**
+   * Returns the nearest place to the given latitude and longitude by elucidaian distance
+   * @param latitude the latitude to search near, range [-90,90]
+   * @param longitude the longitude to search near, range [-180,80]
+   * @return geoJSON string representing the found place
+   */
+	public String getNearbyPlace(double latitude, double longitude) {
+	  return placesRepo.getNearestPlace(latitude, longitude);
+  }
+
 }

--- a/src/test/java/com/climatetree/places/controller/PlacesControllerTest.java
+++ b/src/test/java/com/climatetree/places/controller/PlacesControllerTest.java
@@ -4,6 +4,7 @@ package com.climatetree.places.controller;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
@@ -64,4 +65,14 @@ public class PlacesControllerTest {
 		mvc.perform(get("/api/places/1/similar?populationStart=90&populationEnd=100").contentType(APPLICATION_JSON)).andExpect(status().isOk())
 				.andExpect(jsonPath("$", is(geoJsonString)));
 	}
+
+	@Test
+  public void getNearestPlaceTest() throws Exception {
+    String geoJsonString = "Test Dummy Geo Json String";
+
+    when(placeService.getNearbyPlace(anyDouble(),anyDouble())).thenReturn(geoJsonString);
+
+    mvc.perform(get("/api/places/nearest?latitude=47&longitude=-122").contentType(APPLICATION_JSON))
+        .andExpect(status().isOk()).andExpect(jsonPath("$", is(geoJsonString)));
+  }
 }

--- a/src/test/java/com/climatetree/places/service/PlacesServiceTest.java
+++ b/src/test/java/com/climatetree/places/service/PlacesServiceTest.java
@@ -74,4 +74,13 @@ public class PlacesServiceTest {
 		assertThat(places).isEqualTo("");
 	}
 
+	@Test
+  public void getNearestTest() {
+	  when(repo.getNearestPlace(anyDouble(), anyDouble())).thenReturn(this.json_object);
+
+	  String result = service.getNearbyPlace(0,0);
+
+	  assertThat(result).isEqualTo("Json Object");
+  }
+
 }


### PR DESCRIPTION
### Change type:
- Adds new endpoint that returns the nearest place to a pair of coordinates in the database, mapped to /api/places/nearest

### Description:
- Adds query that finds the nearest point in the database by euclidean distance to a pair of WGS84 coordinates
- Updates controller to accept a new mapping /api/places/nearest that accepts two query parameters latitude and longitude
- Example API call (running on localhost:8080): http://localhost:8080/api/places/nearest?latitude=47&longitude=-122 should return a Pierce County geoJSON object
- latitude should range [-90,90] and longitude [-180,180]. 

### Trello Card Link:
https://trello.com/c/D1Vq2gQ1/37-implement-api-that-returns-the-closest-place-in-our-database

### PR Checklist:
- [x] Changes do not introduce new warnings or errors
- [x] Tests were added or modified to cover changes
- [x] All new and existing tests pass

### Steps to Verify Pull Request
- Review new query
- Review new endpoint and parameters
- Review new tests
- Run locally and determine if nearest endpoint is giving sensible results. 

